### PR TITLE
Make UIColor hexString initializer bailable

### DIFF
--- a/SwiftUtils/UIColor.swift
+++ b/SwiftUtils/UIColor.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public extension UIColor {
 
-    convenience init(hexString: String) {
+    convenience init?(hexString: String) {
         let hexString = hexString.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
         let scanner = NSScanner(string: hexString)
 
@@ -18,8 +18,9 @@ public extension UIColor {
             scanner.scanLocation = 1
         }
 
-        var color: UInt32 = 0
-        scanner.scanHexInt(&color)
+        guard let color = scanner.scanHexInt() else {
+            return nil
+        }
 
         let mask = 0x000000FF
         let r = Int(color >> 16) & mask
@@ -32,4 +33,5 @@ public extension UIColor {
 
         self.init(red: red, green: green, blue: blue, alpha: 1)
     }
+
 }

--- a/SwiftUtilsTests/UIColor-Tests.swift
+++ b/SwiftUtilsTests/UIColor-Tests.swift
@@ -15,4 +15,9 @@ class UIColor_Tests: XCTestCase {
         let RGBColor = UIColor(red: 59/255, green: 63/255, blue: 64/255, alpha: 1)
         XCTAssertEqual(color, RGBColor)
     }
+
+    func testColorWithGarbageString() {
+        XCTAssertNil(UIColor(hexString: "garbage"))
+    }
+
 }


### PR DESCRIPTION
You can pass any arbitrary String into this initializer, so if we can't read a hex int from it, fail the initializer.