### PR TITLE
Fix bug in NSDateComponents+Offset

### DIFF
--- a/SwiftUtils/NSDateComponents+Offset.swift
+++ b/SwiftUtils/NSDateComponents+Offset.swift
@@ -27,7 +27,9 @@ extension NSDateComponents {
             return nil
         }
         calendar.timeZone = timeZone
-        return calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second, .TimeZone], fromDate: date)
+        let components = calendar.components([.Year, .Month, .Day, .Hour, .Minute, .Second, .TimeZone], fromDate: date)
+        components.calendar = calendar
+        return components
     }
 
 }

--- a/SwiftUtilsTests/NSDateComponents+Offset-Tests.swift
+++ b/SwiftUtilsTests/NSDateComponents+Offset-Tests.swift
@@ -35,6 +35,7 @@ class NSDateComponents_Offset_Tests: XCTestCase {
         XCTAssertEqual(0, actual.minute)
         XCTAssertEqual(0, actual.second)
         XCTAssertEqual(0, actual.timeZone!.secondsFromGMT)
+        XCTAssertNotNil(actual.date)
     }
 
     func testGMTToIndia() {
@@ -57,6 +58,7 @@ class NSDateComponents_Offset_Tests: XCTestCase {
         XCTAssertEqual(30, actual.minute)
         XCTAssertEqual(0, actual.second)
         XCTAssertEqual(NSTimeZone.fromOffset("+0530")!.secondsFromGMT, actual.timeZone!.secondsFromGMT)
+        XCTAssertNotNil(actual.date)
     }
 
     func testArizonaToIndia() {
@@ -79,6 +81,7 @@ class NSDateComponents_Offset_Tests: XCTestCase {
         XCTAssertEqual(30, actual.minute)
         XCTAssertEqual(0, actual.second)
         XCTAssertEqual(NSTimeZone.fromOffset("+0530")!.secondsFromGMT, actual.timeZone!.secondsFromGMT)
+        XCTAssertNotNil(actual.date)
     }
 
 }


### PR DESCRIPTION
If the calendar property of NSDateComponents is not set, you can't safely call date! on it. Since we only ever work in the gregorian calendar, set it.