### PR TITLE
Include : in NSTimezone offset

### DIFF
--- a/SwiftUtils/NSTimeZone+Offset.swift
+++ b/SwiftUtils/NSTimeZone+Offset.swift
@@ -87,7 +87,7 @@ extension NSTimeZone {
             }
             let hours = abs(secondsFromGMT) / (60 * 60)
             let minutes = (abs(secondsFromGMT) % (60 * 60)) / 60
-            return sign + String.init(format: "%02d%02d", hours, minutes)
+            return sign + String.init(format: "%02d:%02d", hours, minutes)
         }
     }
 

--- a/SwiftUtilsTests/NSTimeZone+Offset-Tests.swift
+++ b/SwiftUtilsTests/NSTimeZone+Offset-Tests.swift
@@ -18,7 +18,7 @@ class NSTimeZone_Offset_Tests: XCTestCase {
     func testIndia() {
         testFromOffset(actual: NSTimeZone.fromOffset("+0530")!, expected: NSTimeZone.init(name: "Asia/Kolkata")!)
         testFromOffset(actual: NSTimeZone.fromOffset("+05:30")!, expected: NSTimeZone.init(name: "Asia/Kolkata")!)
-        XCTAssertEqual(NSTimeZone.init(name: "Asia/Kolkata")?.offset, "+0530")
+        XCTAssertEqual(NSTimeZone.init(name: "Asia/Kolkata")?.offset, "+05:30")
     }
 
     func testGMT() {
@@ -31,7 +31,7 @@ class NSTimeZone_Offset_Tests: XCTestCase {
     func testArizona() {
         testFromOffset(actual: NSTimeZone.fromOffset("-0700")!, expected: NSTimeZone.init(name: "America/Phoenix")!)
         testFromOffset(actual: NSTimeZone.fromOffset("-07:00")!, expected: NSTimeZone.init(name: "America/Phoenix")!)
-        XCTAssertEqual(NSTimeZone.init(name: "America/Phoenix")?.offset, "-0700")
+        XCTAssertEqual(NSTimeZone.init(name: "America/Phoenix")?.offset, "-07:00")
     }
 
     private func testFromOffset(actual actual: NSTimeZone, expected: NSTimeZone) {


### PR DESCRIPTION
Although some parsers do work wihthout the :, the one we use on the server side doesn't.